### PR TITLE
Allow the Serialization of `FragmentPerms`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,15 @@ license = "BSD-3-Clause"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0.136", features = ["derive"], optional = true }
+serde = { version = "1.0.136", features = ["derive"], default-features = false } # optional = true }
 scale-info = { version = "2.0", features = ["derive"], default-features = false }
 parity-scale-codec = { version = "3.0", features = ["derive"], default-features = false }
 bitflags = "1.3.2"
 
 [features]
 default = ["std"]
-std = ["serde", "parity-scale-codec/std", "scale-info/std"]
+std = [
+#    "serde",
+    "parity-scale-codec/std",
+    "scale-info/std"
+]

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -1,9 +1,11 @@
 use bitflags::bitflags;
 use parity_scale_codec::{Decode, Encode};
 
+use serde::Serialize;
+
 bitflags! {
   /// Permissions for fragments and fragment's bundles.
-  #[derive(Encode, Decode, scale_info::TypeInfo)]
+  #[derive(Encode, Decode, scale_info::TypeInfo, Serialize)]
   pub struct FragmentPerms: u32 {
     const NONE = 0;
     const EDIT = 1;


### PR DESCRIPTION
We use a serialised `FragmentPerms` in the runtime function `get_instances()` in this clamor PR: https://github.com/fragcolor-xyz/clamor/blob/04cfa97436cb51d2410d5b897adcbcf5e75032aa/pallets/fragments/src/lib.rs#L1594-L1641

